### PR TITLE
Introducing Gazebo support for RX160/RX160L

### DIFF
--- a/staubli_experimental/package.xml
+++ b/staubli_experimental/package.xml
@@ -12,6 +12,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <run_depend>staubli_rx160_gazebo</run_depend>
+
   <export>
     <metapackage/>
   </export>

--- a/staubli_rx160_gazebo/CMakeLists.txt
+++ b/staubli_rx160_gazebo/CMakeLists.txt
@@ -6,4 +6,4 @@ find_package(catkin REQUIRED)
 catkin_package()
 
 install(DIRECTORY config launch urdf
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/staubli_rx160_gazebo/CMakeLists.txt
+++ b/staubli_rx160_gazebo/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(staubli_rx160_gazebo)
+
+find_package(catkin REQUIRED)
+
+catkin_package()
+
+foreach(dir config launch urdf)
+   install(DIRECTORY ${dir}/
+      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
+endforeach()

--- a/staubli_rx160_gazebo/CMakeLists.txt
+++ b/staubli_rx160_gazebo/CMakeLists.txt
@@ -5,7 +5,5 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-foreach(dir config launch urdf)
-   install(DIRECTORY ${dir}/
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach()
+install(DIRECTORY config launch urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}

--- a/staubli_rx160_gazebo/config/joint_state_controller.yaml
+++ b/staubli_rx160_gazebo/config/joint_state_controller.yaml
@@ -1,0 +1,3 @@
+joint_state_controller:
+    type: joint_state_controller/JointStateController
+    publish_rate: 50  

--- a/staubli_rx160_gazebo/config/joint_state_controller.yaml
+++ b/staubli_rx160_gazebo/config/joint_state_controller.yaml
@@ -1,3 +1,3 @@
 joint_state_controller:
-    type: joint_state_controller/JointStateController
-    publish_rate: 50  
+  type: joint_state_controller/JointStateController
+  publish_rate: 50  

--- a/staubli_rx160_gazebo/config/rx160_arm_controller.yaml
+++ b/staubli_rx160_gazebo/config/rx160_arm_controller.yaml
@@ -1,0 +1,21 @@
+arm_controller:
+  type: position_controllers/JointTrajectoryController
+  joints:
+     - joint_1
+     - joint_2
+     - joint_3
+     - joint_4
+     - joint_5
+     - joint_6
+  constraints:
+      goal_time: 0.6
+      stopped_velocity_tolerance: 0.05
+      joint_1: {trajectory: 0.1, goal: 0.1}
+      joint_2: {trajectory: 0.1, goal: 0.1}
+      joint_3: {trajectory: 0.1, goal: 0.1}
+      joint_4: {trajectory: 0.1, goal: 0.1}
+      joint_5: {trajectory: 0.1, goal: 0.1}
+      joint_6: {trajectory: 0.1, goal: 0.1}
+  stop_trajectory_duration: 0.5
+  state_publish_rate:  25
+  action_monitor_rate: 10

--- a/staubli_rx160_gazebo/config/rx160_arm_controller.yaml
+++ b/staubli_rx160_gazebo/config/rx160_arm_controller.yaml
@@ -1,21 +1,21 @@
 arm_controller:
   type: position_controllers/JointTrajectoryController
   joints:
-     - joint_1
-     - joint_2
-     - joint_3
-     - joint_4
-     - joint_5
-     - joint_6
+    - joint_1
+    - joint_2
+    - joint_3
+    - joint_4
+    - joint_5
+    - joint_6
   constraints:
-      goal_time: 0.6
-      stopped_velocity_tolerance: 0.05
-      joint_1: {trajectory: 0.1, goal: 0.1}
-      joint_2: {trajectory: 0.1, goal: 0.1}
-      joint_3: {trajectory: 0.1, goal: 0.1}
-      joint_4: {trajectory: 0.1, goal: 0.1}
-      joint_5: {trajectory: 0.1, goal: 0.1}
-      joint_6: {trajectory: 0.1, goal: 0.1}
+    goal_time: 0.6
+    stopped_velocity_tolerance: 0.05
+    joint_1: {trajectory: 0.1, goal: 0.1}
+    joint_2: {trajectory: 0.1, goal: 0.1}
+    joint_3: {trajectory: 0.1, goal: 0.1}
+    joint_4: {trajectory: 0.1, goal: 0.1}
+    joint_5: {trajectory: 0.1, goal: 0.1}
+    joint_6: {trajectory: 0.1, goal: 0.1}
   stop_trajectory_duration: 0.5
   state_publish_rate:  25
   action_monitor_rate: 10

--- a/staubli_rx160_gazebo/launch/load_rx160.launch
+++ b/staubli_rx160_gazebo/launch/load_rx160.launch
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<launch>
+  <param name="robot_description" command="$(find xacro)/xacro.py '$(find staubli_rx160_gazebo)/urdf/rx160.xacro'" />
+</launch>

--- a/staubli_rx160_gazebo/launch/load_rx160l.launch
+++ b/staubli_rx160_gazebo/launch/load_rx160l.launch
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<launch>
+  <param name="robot_description" command="$(find xacro)/xacro.py '$(find staubli_rx160_gazebo)/urdf/rx160l.xacro'" />
+</launch>

--- a/staubli_rx160_gazebo/launch/rx160_control.launch
+++ b/staubli_rx160_gazebo/launch/rx160_control.launch
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- load the joint state controller -->
+  <rosparam file="$(find staubli_rx160_gazebo)/config/joint_state_controller.yaml" command="load" />
+  <node name="joint_state_controller_spawner" pkg="controller_manager" type="spawner" args="joint_state_controller --shutdown-timeout 1" />
+
+  <!-- load the arm controller -->
+  <rosparam file="$(find staubli_rx160_gazebo)/config/rx160_arm_controller.yaml" command="load" />
+  <node name="staubli_rx160_controller_spawner" pkg="controller_manager" type="spawner" args="arm_controller --shutdown-timeout 1" />
+</launch>

--- a/staubli_rx160_gazebo/launch/rx160_gazebo.launch
+++ b/staubli_rx160_gazebo/launch/rx160_gazebo.launch
@@ -2,18 +2,30 @@
 <launch>
   <arg name="paused" default="false"/>
   <arg name="gui" default="true"/>
+  <arg name="remap" default="false"/>
   
-  <!-- remap topics to conform to ROS-I specifications -->
-  <remap from="arm_controller/follow_joint_trajectory" to="/joint_trajectory_action" />
-  <remap from="arm_controller/state" to="/feedback_states" />
-  <remap from="arm_controller/command" to="/joint_path_command"/>
-
-  <!-- startup simulated world -->
-  <include file="$(find gazebo_ros)/launch/empty_world.launch">
-    <arg name="world_name" value="worlds/empty.world"/>
-    <arg name="gui" value="$(arg gui)"/>
-    <arg name="paused" value="$(arg paused)"/>
-  </include>
+  <group if="$(arg remap)">
+    <!-- remap topics to conform to ROS-I specifications -->
+    <remap from="/arm_controller/follow_joint_trajectory" to="/joint_trajectory_action" />
+    <remap from="/arm_controller/state" to="/feedback_states" />
+    <remap from="/arm_controller/command" to="/joint_path_command"/>
+    
+    <!-- startup simulated world -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+      <arg name="world_name" value="worlds/empty.world"/>
+      <arg name="gui" value="$(arg gui)"/>
+      <arg name="paused" value="$(arg paused)"/>
+    </include>
+  </group>
+  
+  <group unless="$(arg remap)">
+    <!-- startup simulated world -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+      <arg name="world_name" value="worlds/empty.world"/>
+      <arg name="gui" value="$(arg gui)"/>
+      <arg name="paused" value="$(arg paused)"/>
+    </include>
+  </group>
   
   <!-- send robot URDF to ROS param server,
        and spawn robot in Gazebo, along with necessary ROS nodes -->

--- a/staubli_rx160_gazebo/launch/rx160_gazebo.launch
+++ b/staubli_rx160_gazebo/launch/rx160_gazebo.launch
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<launch>
+	<arg name="paused" default="false"/>
+	<arg name="gui" default="true"/>
+
+  <!-- startup simulated world -->
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="world_name" value="worlds/empty.world"/>
+    <arg name="gui" value="$(arg gui)"/>
+    <arg name="paused" value="$(arg paused)"/>
+  </include>
+  
+  <!-- send robot URDF to ROS param server,
+       and spawn robot in Gazebo, along with necessary ROS nodes -->
+  <include file="$(find staubli_rx160_gazebo)/launch/spawn_rx160.launch"/>
+  
+</launch>

--- a/staubli_rx160_gazebo/launch/rx160_gazebo.launch
+++ b/staubli_rx160_gazebo/launch/rx160_gazebo.launch
@@ -1,7 +1,12 @@
 <?xml version="1.0"?>
 <launch>
-	<arg name="paused" default="false"/>
-	<arg name="gui" default="true"/>
+  <arg name="paused" default="false"/>
+  <arg name="gui" default="true"/>
+  
+  <!-- remap topics to conform to ROS-I specifications -->
+  <remap from="arm_controller/follow_joint_trajectory" to="/joint_trajectory_action" />
+  <remap from="arm_controller/state" to="/feedback_states" />
+  <remap from="arm_controller/command" to="/joint_path_command"/>
 
   <!-- startup simulated world -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">

--- a/staubli_rx160_gazebo/launch/rx160l_gazebo.launch
+++ b/staubli_rx160_gazebo/launch/rx160l_gazebo.launch
@@ -2,18 +2,30 @@
 <launch>
   <arg name="paused" default="false"/>
   <arg name="gui" default="true"/>
+  <arg name="remap" default="false"/>
   
-  <!-- remap topics to conform to ROS-I specifications -->
-  <remap from="arm_controller/follow_joint_trajectory" to="/joint_trajectory_action" />
-  <remap from="arm_controller/state" to="/feedback_states" />
-  <remap from="arm_controller/command" to="/joint_path_command"/>
-
-  <!-- startup simulated world -->
-  <include file="$(find gazebo_ros)/launch/empty_world.launch">
-    <arg name="world_name" value="worlds/empty.world"/>
-    <arg name="gui" value="$(arg gui)"/>
-    <arg name="paused" value="$(arg paused)"/>
-  </include>
+  <group if="$(arg remap)">
+    <!-- remap topics to conform to ROS-I specifications -->
+    <remap from="/arm_controller/follow_joint_trajectory" to="/joint_trajectory_action" />
+    <remap from="/arm_controller/state" to="/feedback_states" />
+    <remap from="/arm_controller/command" to="/joint_path_command"/>
+    
+    <!-- startup simulated world -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+      <arg name="world_name" value="worlds/empty.world"/>
+      <arg name="gui" value="$(arg gui)"/>
+      <arg name="paused" value="$(arg paused)"/>
+    </include>
+  </group>
+  
+  <group unless="$(arg remap)">
+    <!-- startup simulated world -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+      <arg name="world_name" value="worlds/empty.world"/>
+      <arg name="gui" value="$(arg gui)"/>
+      <arg name="paused" value="$(arg paused)"/>
+    </include>
+  </group>
   
   <!-- send robot URDF to ROS param server,
        and spawn robot in Gazebo, along with necessary ROS nodes -->

--- a/staubli_rx160_gazebo/launch/rx160l_gazebo.launch
+++ b/staubli_rx160_gazebo/launch/rx160l_gazebo.launch
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="paused" default="false"/>
+  <arg name="gui" default="true"/>
+  
+  <!-- remap topics to conform to ROS-I specifications -->
+  <remap from="arm_controller/follow_joint_trajectory" to="/joint_trajectory_action" />
+  <remap from="arm_controller/state" to="/feedback_states" />
+  <remap from="arm_controller/command" to="/joint_path_command"/>
+
+  <!-- startup simulated world -->
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="world_name" value="worlds/empty.world"/>
+    <arg name="gui" value="$(arg gui)"/>
+    <arg name="paused" value="$(arg paused)"/>
+  </include>
+  
+  <!-- send robot URDF to ROS param server,
+       and spawn robot in Gazebo, along with necessary ROS nodes -->
+  <include file="$(find staubli_rx160_gazebo)/launch/spawn_rx160l.launch"/>
+  
+</launch>

--- a/staubli_rx160_gazebo/launch/spawn_rx160.launch
+++ b/staubli_rx160_gazebo/launch/spawn_rx160.launch
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<launch>  
+
+  <!-- remap topics to conform to ROS-I specifications -->
+  <remap from="/arm_controller/follow_joint_trajectory" to="/joint_trajectory_action" />
+  <remap from="/arm_controller/state" to="/feedback_states" />
+  <remap from="/arm_controller/command" to="/joint_path_command"/>
+
+  <!-- send robot urdf to ROS param server -->
+  <include file="$(find staubli_rx160_gazebo)/launch/load_rx160.launch" />
+
+  <!-- push robot_description to factory and spawn robot in gazebo -->
+  <node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" 
+        output="screen" respawn="false"
+        args="-urdf
+              -param robot_description
+              -model rx160
+              -x 0.0
+              -y 0.0
+              -z 0.0
+              -R 0.0
+              -P 0.0
+              -Y 0.0" />
+
+    <!-- convert joint states to TF transforms for rviz, etc -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"
+  output="screen">
+  </node>
+
+  <!-- init and start Gazebo ros_control interface -->
+  <include file="$(find staubli_rx160_gazebo)/launch/rx160_control.launch"/>
+  
+</launch>

--- a/staubli_rx160_gazebo/launch/spawn_rx160.launch
+++ b/staubli_rx160_gazebo/launch/spawn_rx160.launch
@@ -1,11 +1,5 @@
 <?xml version="1.0"?>
 <launch>  
-
-  <!-- remap topics to conform to ROS-I specifications -->
-  <remap from="/arm_controller/follow_joint_trajectory" to="/joint_trajectory_action" />
-  <remap from="/arm_controller/state" to="/feedback_states" />
-  <remap from="/arm_controller/command" to="/joint_path_command"/>
-
   <!-- send robot urdf to ROS param server -->
   <include file="$(find staubli_rx160_gazebo)/launch/load_rx160.launch" />
 

--- a/staubli_rx160_gazebo/launch/spawn_rx160.launch
+++ b/staubli_rx160_gazebo/launch/spawn_rx160.launch
@@ -22,10 +22,8 @@
               -P 0.0
               -Y 0.0" />
 
-    <!-- convert joint states to TF transforms for rviz, etc -->
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"
-  output="screen">
-  </node>
+  <!-- convert joint states to TF transforms for rviz, etc -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 
   <!-- init and start Gazebo ros_control interface -->
   <include file="$(find staubli_rx160_gazebo)/launch/rx160_control.launch"/>

--- a/staubli_rx160_gazebo/launch/spawn_rx160l.launch
+++ b/staubli_rx160_gazebo/launch/spawn_rx160l.launch
@@ -1,11 +1,5 @@
 <?xml version="1.0"?>
 <launch>  
-
-  <!-- remap topics to conform to ROS-I specifications -->
-  <remap from="/arm_controller/follow_joint_trajectory" to="/joint_trajectory_action" />
-  <remap from="/arm_controller/state" to="/feedback_states" />
-  <remap from="/arm_controller/command" to="/joint_path_command"/>
-
   <!-- send robot urdf to ROS param server -->
   <include file="$(find staubli_rx160_gazebo)/launch/load_rx160l.launch" />
 

--- a/staubli_rx160_gazebo/launch/spawn_rx160l.launch
+++ b/staubli_rx160_gazebo/launch/spawn_rx160l.launch
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<launch>  
+
+  <!-- remap topics to conform to ROS-I specifications -->
+  <remap from="/arm_controller/follow_joint_trajectory" to="/joint_trajectory_action" />
+  <remap from="/arm_controller/state" to="/feedback_states" />
+  <remap from="/arm_controller/command" to="/joint_path_command"/>
+
+  <!-- send robot urdf to ROS param server -->
+  <include file="$(find staubli_rx160_gazebo)/launch/load_rx160l.launch" />
+
+  <!-- push robot_description to factory and spawn robot in gazebo -->
+  <node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" 
+        output="screen" respawn="false"
+        args="-urdf
+              -param robot_description
+              -model rx160l
+              -x 0.0
+              -y 0.0
+              -z 0.0
+              -R 0.0
+              -P 0.0
+              -Y 0.0" />
+
+    <!-- convert joint states to TF transforms for rviz, etc -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"
+  output="screen">
+  </node>
+
+  <!-- init and start Gazebo ros_control interface -->
+  <include file="$(find staubli_rx160_gazebo)/launch/rx160_control.launch"/>
+  
+</launch>

--- a/staubli_rx160_gazebo/launch/spawn_rx160l.launch
+++ b/staubli_rx160_gazebo/launch/spawn_rx160l.launch
@@ -22,10 +22,8 @@
               -P 0.0
               -Y 0.0" />
 
-    <!-- convert joint states to TF transforms for rviz, etc -->
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"
-  output="screen">
-  </node>
+  <!-- convert joint states to TF transforms for rviz, etc -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 
   <!-- init and start Gazebo ros_control interface -->
   <include file="$(find staubli_rx160_gazebo)/launch/rx160_control.launch"/>

--- a/staubli_rx160_gazebo/package.xml
+++ b/staubli_rx160_gazebo/package.xml
@@ -17,7 +17,6 @@
     </p>
   </description>
   <author email="murilo.martins@ocado.com">Murilo Martins (Ocado Technology)</author>
-  <maintainer>Murilo Martins (Ocado Technology)</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>Apache2.0</license>
 

--- a/staubli_rx160_gazebo/package.xml
+++ b/staubli_rx160_gazebo/package.xml
@@ -17,16 +17,17 @@
     </p>
   </description>
   <author email="murilo.martins@ocado.com">Murilo Martins (Ocado Technology)</author>
-  <maintainer email="murilo.martins@ocado.com">Murilo Martins (Ocado Technology)</maintainer>
+  <maintainer>Murilo Martins (Ocado Technology)</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>Apache2.0</license>
 
-  <url type="website">http://wiki.ros.org/staubli</url>
-  <url type="bugtracker">https://github.com/ros-industrial/staubli/issues</url>
-  <url type="repository">https://github.com/ros-industrial/staubli</url>
+  <url type="website">http://wiki.ros.org/staubli_experimental</url>
+  <url type="bugtracker">https://github.com/ros-industrial/staubli_experimental/issues</url>
+  <url type="repository">https://github.com/ros-industrial/staubli_experimental</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>staubli_rx160_resources</run_depend>
+  <run_depend>staubli_resources</run_depend>
   <run_depend>staubli_rx160_support</run_depend>
   <run_depend>gazebo</run_depend>
   <run_depend>gazebo_ros</run_depend>

--- a/staubli_rx160_gazebo/package.xml
+++ b/staubli_rx160_gazebo/package.xml
@@ -1,0 +1,40 @@
+<package>
+  <name>staubli_rx160_gazebo</name>
+  <version>0.0.1</version>
+  <description>
+    <p>
+      ROS-Industrial Gazebo support package for the Staubli RX160 (and variants).
+    </p>
+    <p>
+      This package contains the configuration data and launch files required
+      to simulate the Staubli RX160 manipulator in Gazebo. This includes the base
+      model and the RX160L.
+    </p>
+    <p>
+      Before using any of the configuration files included in this package, be
+      sure to check they are correct for the particular robot model and
+      configuration you intend to use them with.
+    </p>
+  </description>
+  <author email="murilo.martins@ocado.com">Murilo Martins (Ocado Technology)</author>
+  <maintainer email="murilo.martins@ocado.com">Murilo Martins (Ocado Technology)</maintainer>
+  <license>Apache2.0</license>
+
+  <url type="website">http://wiki.ros.org/staubli</url>
+  <url type="bugtracker">https://github.com/ros-industrial/staubli/issues</url>
+  <url type="repository">https://github.com/ros-industrial/staubli</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <run_depend>staubli_rx160_resources</run_depend>
+  <run_depend>staubli_rx160_support</run_depend>
+  <run_depend>gazebo</run_depend>
+  <run_depend>gazebo_ros</run_depend>
+  <run_depend>gazebo_ros_control</run_depend>
+  <run_depend>gazebo_ros_pkgs</run_depend>
+  <run_depend>joint_state_controller</run_depend>
+  <run_depend>position_controllers</run_depend>
+  <run_depend>joint_trajectory_controller</run_depend>
+  <run_depend>robot_state_publisher</run_depend>
+  <run_depend>ros_controllers</run_depend>
+</package>

--- a/staubli_rx160_gazebo/urdf/rx160.xacro
+++ b/staubli_rx160_gazebo/urdf/rx160.xacro
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<robot name="staubli_rx160_gazebo" xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- RX160 -->
+  <xacro:include filename="$(find staubli_rx160_gazebo)/urdf/rx160_macro.xacro"/>	
+  
+  <xacro:staubli_rx160_robot prefix=""/>
+
+  <!-- Fix robot to Gazebo world -->
+  <link name="world"/>
+  <joint name="world-base_link-fixed" type="fixed">
+    <parent link="world"/>
+    <child link="base_link"/>
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
+</robot>

--- a/staubli_rx160_gazebo/urdf/rx160_macro.xacro
+++ b/staubli_rx160_gazebo/urdf/rx160_macro.xacro
@@ -91,7 +91,7 @@
     <turnGravityOff>true</turnGravityOff>
   </gazebo>
   <gazebo reference="${prefix}link_5">
-    <material>Gazebo/Yellow</material>
+    <material>Gazebo/Grey</material>
     <turnGravityOff>true</turnGravityOff>
   </gazebo>
   <gazebo reference="${prefix}link_6">

--- a/staubli_rx160_gazebo/urdf/rx160_macro.xacro
+++ b/staubli_rx160_gazebo/urdf/rx160_macro.xacro
@@ -1,0 +1,111 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<xacro:include filename="$(find staubli_rx160_support)/urdf/rx160_macro.xacro"/>
+<xacro:macro name="staubli_rx160_robot" params="prefix">
+
+  <!-- get URDF description of Staubli RX160 model -->
+  <xacro:staubli_rx160 prefix="${prefix}" />
+
+  <!-- transmission list -->
+  <transmission name="${prefix}tran1">
+    <robotNamespace>/${prefix}</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="${prefix}joint_1">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="${prefix}motor1">
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="${prefix}tran2">
+    <robotNamespace>/${prefix}</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="${prefix}joint_2">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="${prefix}motor2">
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="${prefix}tran3">
+    <robotNamespace>/${prefix}</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="${prefix}joint_3">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="${prefix}motor3">
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="${prefix}tran4">
+    <robotNamespace>/${prefix}</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="${prefix}joint_4">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="${prefix}motor4">
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="${prefix}tran5">
+    <robotNamespace>/${prefix}</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="${prefix}joint_5">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="${prefix}motor5">
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="${prefix}tran6">
+    <robotNamespace>/${prefix}</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="${prefix}joint_6">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="${prefix}motor6">
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <!-- end of transmission list -->
+
+  <!-- Gazebo-specific link properties -->
+  <gazebo reference="${prefix}base_link">
+    <material>Gazebo/Yellow</material>
+    <turnGravityOff>true</turnGravityOff>
+  </gazebo>
+  <gazebo reference="${prefix}link_1">
+    <material>Gazebo/Yellow</material>
+    <turnGravityOff>true</turnGravityOff>
+  </gazebo>
+  <gazebo reference="${prefix}link_2">
+    <material>Gazebo/Yellow</material>
+    <turnGravityOff>true</turnGravityOff>
+  </gazebo>  
+  <gazebo reference="${prefix}link_3">
+    <material>Gazebo/Yellow</material>
+    <turnGravityOff>true</turnGravityOff>
+  </gazebo>
+  <gazebo reference="${prefix}link_4">
+    <material>Gazebo/Yellow</material>
+    <turnGravityOff>true</turnGravityOff>
+  </gazebo>
+  <gazebo reference="${prefix}link_5">
+    <material>Gazebo/Yellow</material>
+    <turnGravityOff>true</turnGravityOff>
+  </gazebo>
+  <gazebo reference="${prefix}link_6">
+    <material>Gazebo/Grey</material>
+    <turnGravityOff>true</turnGravityOff>
+  </gazebo>
+
+  <!-- ros_control plugin -->
+  <gazebo>
+    <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
+      <robotNamespace>/${prefix}</robotNamespace>
+      <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
+    </plugin>
+  </gazebo>  
+
+  </xacro:macro>
+</robot>

--- a/staubli_rx160_gazebo/urdf/rx160l.xacro
+++ b/staubli_rx160_gazebo/urdf/rx160l.xacro
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<robot name="staubli_rx160l_gazebo" xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- RX160L -->
+  <xacro:include filename="$(find staubli_rx160_gazebo)/urdf/rx160l_macro.xacro"/>
+  
+  <xacro:staubli_rx160l_robot prefix=""/>
+
+  <!-- Fix robot to Gazebo world -->
+  <link name="world"/>
+  <joint name="world-base_link-fixed" type="fixed">
+    <parent link="world"/>
+    <child link="base_link"/>
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+  </joint>
+</robot>

--- a/staubli_rx160_gazebo/urdf/rx160l_macro.xacro
+++ b/staubli_rx160_gazebo/urdf/rx160l_macro.xacro
@@ -1,0 +1,111 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<xacro:include filename="$(find staubli_rx160_support)/urdf/rx160l_macro.xacro"/>
+<xacro:macro name="staubli_rx160l_robot" params="prefix">
+
+  <!-- get URDF description of Staubli RX160L model -->
+  <xacro:staubli_rx160l prefix="${prefix}" />
+
+  <!-- transmission list -->
+  <transmission name="${prefix}tran1">
+    <robotNamespace>/${prefix}</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="${prefix}joint_1">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="${prefix}motor1">
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="${prefix}tran2">
+    <robotNamespace>/${prefix}</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="${prefix}joint_2">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="${prefix}motor2">
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="${prefix}tran3">
+    <robotNamespace>/${prefix}</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="${prefix}joint_3">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="${prefix}motor3">
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="${prefix}tran4">
+    <robotNamespace>/${prefix}</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="${prefix}joint_4">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="${prefix}motor4">
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="${prefix}tran5">
+    <robotNamespace>/${prefix}</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="${prefix}joint_5">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="${prefix}motor5">
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="${prefix}tran6">
+    <robotNamespace>/${prefix}</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="${prefix}joint_6">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="${prefix}motor6">
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <!-- end of transmission list -->
+
+  <!-- Gazebo-specific link properties -->
+  <gazebo reference="${prefix}base_link">
+    <material>Gazebo/Yellow</material>
+    <turnGravityOff>true</turnGravityOff>
+  </gazebo>
+  <gazebo reference="${prefix}link_1">
+    <material>Gazebo/Yellow</material>
+    <turnGravityOff>true</turnGravityOff>
+  </gazebo>
+  <gazebo reference="${prefix}link_2">
+    <material>Gazebo/Yellow</material>
+    <turnGravityOff>true</turnGravityOff>
+  </gazebo>  
+  <gazebo reference="${prefix}link_3">
+    <material>Gazebo/Yellow</material>
+    <turnGravityOff>true</turnGravityOff>
+  </gazebo>
+  <gazebo reference="${prefix}link_4">
+    <material>Gazebo/Yellow</material>
+    <turnGravityOff>true</turnGravityOff>
+  </gazebo>
+  <gazebo reference="${prefix}link_5">
+    <material>Gazebo/Yellow</material>
+    <turnGravityOff>true</turnGravityOff>
+  </gazebo>
+  <gazebo reference="${prefix}link_6">
+    <material>Gazebo/Grey</material>
+    <turnGravityOff>true</turnGravityOff>
+  </gazebo>
+
+  <!-- ros_control plugin -->
+  <gazebo>
+    <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
+      <robotNamespace>/${prefix}</robotNamespace>
+      <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
+    </plugin>
+  </gazebo>  
+
+  </xacro:macro>
+</robot>

--- a/staubli_rx160_gazebo/urdf/rx160l_macro.xacro
+++ b/staubli_rx160_gazebo/urdf/rx160l_macro.xacro
@@ -91,7 +91,7 @@
     <turnGravityOff>true</turnGravityOff>
   </gazebo>
   <gazebo reference="${prefix}link_5">
-    <material>Gazebo/Yellow</material>
+    <material>Gazebo/Grey</material>
     <turnGravityOff>true</turnGravityOff>
   </gazebo>
   <gazebo reference="${prefix}link_6">


### PR DESCRIPTION
This pull request adds the Gazebo-related files necessary to simulate the Staubli RX160/RX160L robots in Gazebo 2.x.

Note that in order for this package to work, the changes to the `ros-industrial/staubli` repository must be applied. See ros-industrial/staubli#15.
