### PR TITLE
Added mising package dependency

### DIFF
--- a/staubli_experimental/package.xml
+++ b/staubli_experimental/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <run_depend>staubli_rx160_support</run_depend>
   <run_depend>staubli_rx160_gazebo</run_depend>
 
   <export>


### PR DESCRIPTION
There was a missing dependency on the `staubli_rx160_support` package from `ros-industrial/staubli`.
