### PR TITLE
Kinetic devel - Deprecated syntax removal for tx60, tx90 and rx160 gazebo packages

### DIFF
--- a/staubli_rx160_gazebo/launch/rx160_control.launch
+++ b/staubli_rx160_gazebo/launch/rx160_control.launch
@@ -2,9 +2,9 @@
 <launch>
   <!-- load the joint state controller -->
   <rosparam file="$(find staubli_rx160_gazebo)/config/joint_state_controller.yaml" command="load" />
-  <node name="joint_state_controller_spawner" pkg="controller_manager" type="spawner" args="joint_state_controller --shutdown-timeout 1" />
+  <node name="joint_state_controller_spawner" pkg="controller_manager" type="spawner" args="joint_state_controller" />
 
   <!-- load the arm controller -->
   <rosparam file="$(find staubli_rx160_gazebo)/config/rx160_arm_controller.yaml" command="load" />
-  <node name="staubli_rx160_controller_spawner" pkg="controller_manager" type="spawner" args="arm_controller --shutdown-timeout 1" />
+  <node name="staubli_rx160_controller_spawner" pkg="controller_manager" type="spawner" args="arm_controller" />
 </launch>

--- a/staubli_rx160_gazebo/urdf/rx160_macro.xacro
+++ b/staubli_rx160_gazebo/urdf/rx160_macro.xacro
@@ -11,7 +11,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_1">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor1">
       <mechanicalReduction>1</mechanicalReduction>
@@ -21,7 +21,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_2">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor2">
       <mechanicalReduction>1</mechanicalReduction>
@@ -31,7 +31,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_3">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor3">
       <mechanicalReduction>1</mechanicalReduction>
@@ -41,7 +41,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_4">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor4">
       <mechanicalReduction>1</mechanicalReduction>
@@ -51,7 +51,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_5">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor5">
       <mechanicalReduction>1</mechanicalReduction>
@@ -61,7 +61,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_6">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor6">
       <mechanicalReduction>1</mechanicalReduction>

--- a/staubli_rx160_gazebo/urdf/rx160l_macro.xacro
+++ b/staubli_rx160_gazebo/urdf/rx160l_macro.xacro
@@ -11,7 +11,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_1">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor1">
       <mechanicalReduction>1</mechanicalReduction>
@@ -21,7 +21,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_2">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor2">
       <mechanicalReduction>1</mechanicalReduction>
@@ -31,7 +31,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_3">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor3">
       <mechanicalReduction>1</mechanicalReduction>
@@ -41,7 +41,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_4">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor4">
       <mechanicalReduction>1</mechanicalReduction>
@@ -51,7 +51,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_5">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor5">
       <mechanicalReduction>1</mechanicalReduction>
@@ -61,7 +61,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_6">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor6">
       <mechanicalReduction>1</mechanicalReduction>

--- a/staubli_tx60_gazebo/launch/tx60_control.launch
+++ b/staubli_tx60_gazebo/launch/tx60_control.launch
@@ -2,9 +2,9 @@
 <launch>
   <!-- load the joint state controller -->
   <rosparam file="$(find staubli_tx60_gazebo)/config/joint_state_controller.yaml" command="load" />
-  <node name="joint_state_controller_spawner" pkg="controller_manager" type="spawner" args="joint_state_controller --shutdown-timeout 1" />
+  <node name="joint_state_controller_spawner" pkg="controller_manager" type="spawner" args="joint_state_controller" />
 
   <!-- load the arm controller -->
   <rosparam file="$(find staubli_tx60_gazebo)/config/tx60_arm_controller.yaml" command="load" />
-  <node name="staubli_tx60_controller_spawner" pkg="controller_manager" type="spawner" args="arm_controller --shutdown-timeout 1" />
+  <node name="staubli_tx60_controller_spawner" pkg="controller_manager" type="spawner" args="arm_controller" />
 </launch>

--- a/staubli_tx60_gazebo/urdf/tx60_macro.xacro
+++ b/staubli_tx60_gazebo/urdf/tx60_macro.xacro
@@ -11,7 +11,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_1">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor1">
       <mechanicalReduction>1</mechanicalReduction>
@@ -21,7 +21,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_2">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor2">
       <mechanicalReduction>1</mechanicalReduction>
@@ -31,7 +31,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_3">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor3">
       <mechanicalReduction>1</mechanicalReduction>
@@ -41,7 +41,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_4">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor4">
       <mechanicalReduction>1</mechanicalReduction>
@@ -51,7 +51,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_5">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor5">
       <mechanicalReduction>1</mechanicalReduction>
@@ -61,7 +61,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_6">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor6">
       <mechanicalReduction>1</mechanicalReduction>

--- a/staubli_tx60_gazebo/urdf/tx60l_macro.xacro
+++ b/staubli_tx60_gazebo/urdf/tx60l_macro.xacro
@@ -11,7 +11,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_1">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor1">
       <mechanicalReduction>1</mechanicalReduction>
@@ -21,7 +21,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_2">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor2">
       <mechanicalReduction>1</mechanicalReduction>
@@ -31,7 +31,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_3">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor3">
       <mechanicalReduction>1</mechanicalReduction>
@@ -41,7 +41,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_4">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor4">
       <mechanicalReduction>1</mechanicalReduction>
@@ -51,7 +51,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_5">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor5">
       <mechanicalReduction>1</mechanicalReduction>
@@ -61,7 +61,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_6">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor6">
       <mechanicalReduction>1</mechanicalReduction>

--- a/staubli_tx90_gazebo/launch/tx90_control.launch
+++ b/staubli_tx90_gazebo/launch/tx90_control.launch
@@ -2,9 +2,9 @@
 <launch>
   <!-- load the joint state controller -->
   <rosparam file="$(find staubli_tx90_gazebo)/config/joint_state_controller.yaml" command="load" />
-  <node name="joint_state_controller_spawner" pkg="controller_manager" type="spawner" args="joint_state_controller --shutdown-timeout 1" />
+  <node name="joint_state_controller_spawner" pkg="controller_manager" type="spawner" args="joint_state_controller" />
 
   <!-- load the arm controller -->
   <rosparam file="$(find staubli_tx90_gazebo)/config/tx90_arm_controller.yaml" command="load" />
-  <node name="staubli_tx90_controller_spawner" pkg="controller_manager" type="spawner" args="arm_controller --shutdown-timeout 1" />
+  <node name="staubli_tx90_controller_spawner" pkg="controller_manager" type="spawner" args="arm_controller" />
 </launch>

--- a/staubli_tx90_gazebo/urdf/tx90_macro.xacro
+++ b/staubli_tx90_gazebo/urdf/tx90_macro.xacro
@@ -11,7 +11,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_1">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor1">
       <mechanicalReduction>1</mechanicalReduction>
@@ -21,7 +21,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_2">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor2">
       <mechanicalReduction>1</mechanicalReduction>
@@ -31,7 +31,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_3">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor3">
       <mechanicalReduction>1</mechanicalReduction>
@@ -41,7 +41,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_4">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor4">
       <mechanicalReduction>1</mechanicalReduction>
@@ -51,7 +51,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_5">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor5">
       <mechanicalReduction>1</mechanicalReduction>
@@ -61,7 +61,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_6">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor6">
       <mechanicalReduction>1</mechanicalReduction>

--- a/staubli_tx90_gazebo/urdf/tx90l_macro.xacro
+++ b/staubli_tx90_gazebo/urdf/tx90l_macro.xacro
@@ -11,7 +11,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_1">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor1">
       <mechanicalReduction>1</mechanicalReduction>
@@ -21,7 +21,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_2">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor2">
       <mechanicalReduction>1</mechanicalReduction>
@@ -31,7 +31,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_3">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor3">
       <mechanicalReduction>1</mechanicalReduction>
@@ -41,7 +41,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_4">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor4">
       <mechanicalReduction>1</mechanicalReduction>
@@ -51,7 +51,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_5">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor5">
       <mechanicalReduction>1</mechanicalReduction>
@@ -61,7 +61,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_6">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor6">
       <mechanicalReduction>1</mechanicalReduction>

--- a/staubli_tx90_gazebo/urdf/tx90xl_macro.xacro
+++ b/staubli_tx90_gazebo/urdf/tx90xl_macro.xacro
@@ -11,7 +11,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_1">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor1">
       <mechanicalReduction>1</mechanicalReduction>
@@ -21,7 +21,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_2">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor2">
       <mechanicalReduction>1</mechanicalReduction>
@@ -31,7 +31,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_3">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor3">
       <mechanicalReduction>1</mechanicalReduction>
@@ -41,7 +41,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_4">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor4">
       <mechanicalReduction>1</mechanicalReduction>
@@ -51,7 +51,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_5">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor5">
       <mechanicalReduction>1</mechanicalReduction>
@@ -61,7 +61,7 @@
     <robotNamespace>/${prefix}</robotNamespace>
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="${prefix}joint_6">
-      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
     </joint>
     <actuator name="${prefix}motor6">
       <mechanicalReduction>1</mechanicalReduction>


### PR DESCRIPTION
Introducing the removal of warnings about deprecated syntax in the gazebo packages of the tx60, tx90 and rx160 series.

Could I ask you to review and merge?