### PR TITLE
fix #32: do not skip points based on herej()

### DIFF
--- a/staubli_val3_driver/val3/ros_server/motionControl.pgx
+++ b/staubli_val3_driver/val3/ros_server/motionControl.pgx
@@ -48,11 +48,9 @@
       if (l_nElems > 0)
         call libQueueFuncs:pop(qMoveBuffer,l_motion,l_bFlag)
         if (l_bFlag == true)
-          if (l_motion.jJointRx != herej())
-            nMovePts = nMovePts + 1
-            // @TODO potentially set move id according to sequence value
-            nMoveId = movej(l_motion.jJointRx, tTool, l_motion.mDesc)
-          endIf
+          nMovePts = nMovePts + 1
+          // @TODO potentially set move id according to sequence value
+          nMoveId = movej(l_motion.jJointRx, tTool, l_motion.mDesc)
         endIf
       endIf
     else

--- a/staubli_val3_driver/val3/ros_server/motionControl.pgx
+++ b/staubli_val3_driver/val3/ros_server/motionControl.pgx
@@ -49,6 +49,12 @@
         call libQueueFuncs:pop(qMoveBuffer,l_motion,l_bFlag)
         if (l_bFlag == true)
           nMovePts = nMovePts + 1
+          // contrary to what we did earlier, we unconditionally add the traj pt to the motion queue:
+          // there doesn't appear to be a way to compare the 'current pose' of the robot to the pts
+          // in the trajectory at the appropriate time (ie: when the robot is in motion and about to
+          // start executing the segment towards 'l_motion').
+          // Checking for dist(l_motion, herej()) (pseudo code) would not be correct as there will
+          // always be a delay in the data coming out of herej() and the actual pose of the robot.
           // @TODO potentially set move id according to sequence value
           nMoveId = movej(l_motion.jJointRx, tTool, l_motion.mDesc)
         endIf


### PR DESCRIPTION
A longer description of the problem is available on the github issue,
but the basic problem is that this is not evaluated at the correct time
(i.e. when the move is about to be executed), but at the time the move
is being queued, this means having the robot on a paused state already
triggers this problem.

This was tested on simulation on a TX2-60L with CS9 controller.